### PR TITLE
Mobile viewport overflow tweaks

### DIFF
--- a/qr.html
+++ b/qr.html
@@ -59,8 +59,8 @@
 
         body {
             width: 100vw;
-            height: 100vh;
-            max-height: 100vh;
+            height: 100dvh;
+            max-height: 100dvh;
             margin: 0px;
             padding: 0px;
             display: flex;
@@ -77,10 +77,16 @@
             display: flex;
             font-size: 25px;
             padding: 5px;
+            overflow-y: auto;
+            white-space: nowrap;
         }
 
         header a, header .button {
             color: lightgray;
+            margin-right: 20px;
+        }
+
+        header .title {
             margin-right: 20px;
         }
 


### PR DESCRIPTION
This is a very useful tool! Thanks for creating it.  

## Issues
I noticed a couple of things when using this on mobile:
### 1. The header overflows the viewport
This causes a blank gutter on the right:  
<img width="386" height="761" alt="image" src="https://github.com/user-attachments/assets/6eb4540b-32c6-4238-906d-cb4d42d45963" />

### 2. The `100vh` height causes the QR code to be clipped by mobile buttons
After removing the gutter on the right, the QR code is clipped at the bottom of the screen and cannot be scrolled into view:
<img width="386" height="759" alt="image" src="https://github.com/user-attachments/assets/23f2967d-b7a0-42a1-967a-c7f419d9c762" />

## Proposed Changes
1. I've added horizontal scroll to the header to prevent horizontal viewport overflow on mobile.  
  This only activates when the viewport is small enough and can be scrolled left-right via touch.  
2. I've changed the `body` height css from `100vh` to `100dvh` to prevent clipping of the bottom of QR code on mobile.
<img width="386" height="759" alt="image" src="https://github.com/user-attachments/assets/6ad31b44-d2fd-42ba-bd2f-71213275a62e" />


The layout remains unchanged on desktop:

<img width="2879" height="1503" alt="image" src="https://github.com/user-attachments/assets/cdc0249c-0956-48bc-8006-92f1969397c7" />
